### PR TITLE
build: Add basic PHP lint check for PHP 5.6-PHP 7.2 compat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude from WordPress plugin package
+/.* export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+language: php
+php:
+  - "5.5"
+  - "5.6"
+  - "7.0"
+  - "7.1"
+  - "7.2"
+env:
+  global:
+    - COMPOSER_DISABLE_XDEBUG_WARN=1
+install:
+  - composer install
+script:
+  - composer test

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+	"require": {
+		"php": ">=5.5.9"
+	},
+	"require-dev": {
+		"jakub-onderka/php-parallel-lint": "^1.0.0",
+		"jakub-onderka/php-console-highlighter": "^0.3.2"
+	},
+	"scripts": {
+		"test": [
+			"parallel-lint . --exclude vendor"
+		]
+	}
+}


### PR DESCRIPTION
Passing for my fork at <https://travis-ci.com/Krinkle/photocommons/builds/73880209>.

@hay Can you enable this for your repository as well? Log in at <https://travis-ci.com/> with GitHub account, and then toggle the checkbox for this repo. That should make it work.